### PR TITLE
Add Shared VPC support issue #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The [Project Factory module][project-factory-module] and the
 [IAM module][iam-module] may be used in combination to provision a
 service account with the necessary roles applied.
 
+Shared VPC : When the deployment is done in a Shared VPC the following role must be added to the service account in the VPC host project.
+- Compute Admin: `roles/compute.networkUser`
+
 ### APIs
 
 A project with the following APIs enabled must be used to host the

--- a/examples/netweaver_simple_example/README.md
+++ b/examples/netweaver_simple_example/README.md
@@ -34,6 +34,7 @@ Make sure you go through this [Requirements section](../../modules/netweaver/REA
 | boot\_disk\_size | Root disk size in GB. | `any` | n/a | yes |
 | boot\_disk\_type | The GCE boot disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
 | disk\_type | The GCE data disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| host\_project\_id | Shared VPC only - The ID of the host project containing the Shared VPC network. | `string` | `""` | no |
 | instance\_name | A unique name for the resource, required by GCE. Changing this forces a new resource to be created. | `any` | n/a | yes |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |
 | linux\_image\_family | GCE image family. | `any` | n/a | yes |

--- a/examples/netweaver_simple_example/main.tf
+++ b/examples/netweaver_simple_example/main.tf
@@ -35,6 +35,7 @@ module "gcp_netweaver" {
   region                 = var.region
   network_tags           = var.network_tags
   project_id             = var.project_id
+  host_project_id        = var.host_project_id
   zone                   = var.zone
   service_account_email  = var.service_account_email
   boot_disk_size         = var.boot_disk_size

--- a/examples/netweaver_simple_example/variables.tf
+++ b/examples/netweaver_simple_example/variables.tf
@@ -17,6 +17,11 @@ variable "project_id" {
   description = "The ID of the project in which the resources will be deployed."
 }
 
+variable "host_project_id" {
+  description = "Shared VPC only - The ID of the host project containing the Shared VPC network."
+  default     = ""
+}
+
 variable "zone" {
   description = "The zone that the instance should be created in."
 }

--- a/examples/sap_hana_ha_simple_example/README.md
+++ b/examples/sap_hana_ha_simple_example/README.md
@@ -32,6 +32,7 @@ Make sure you go through this [Requirements section](../../modules/sap_hana_ha/R
 |------|-------------|------|---------|:--------:|
 | boot\_disk\_size | Root disk size in GB | `any` | n/a | yes |
 | boot\_disk\_type | The GCE data disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| host\_project\_id | Shared VPC only - The ID of the host project containing the Shared VPC network. | `string` | `""` | no |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |
 | linux\_image\_family | GCE image family. | `any` | n/a | yes |
 | linux\_image\_project | Project name containing the linux image. | `any` | n/a | yes |

--- a/examples/sap_hana_ha_simple_example/main.tf
+++ b/examples/sap_hana_ha_simple_example/main.tf
@@ -27,6 +27,7 @@ module "gcp_sap_hana_ha" {
   instance_type              = var.instance_type
   network_tags               = var.network_tags
   project_id                 = var.project_id
+  host_project_id            = var.host_project_id
   region                     = var.region
   service_account_email      = var.service_account_email
   boot_disk_size             = var.boot_disk_size

--- a/examples/sap_hana_ha_simple_example/variables.tf
+++ b/examples/sap_hana_ha_simple_example/variables.tf
@@ -42,6 +42,11 @@ variable "project_id" {
   description = "The ID of the project in which the resources will be deployed."
 }
 
+variable "host_project_id" {
+  description = "Shared VPC only - The ID of the host project containing the Shared VPC network."
+  default     = ""
+}
+
 variable "region" {
   description = "Region to deploy the resources. Should be in the same region as the zone."
 }

--- a/examples/sap_hana_simple_example/README.md
+++ b/examples/sap_hana_simple_example/README.md
@@ -31,6 +31,7 @@ No provider.
 | autodelete\_disk | Whether the disk will be auto-deleted when the instance is deleted. | `bool` | `true` | no |
 | boot\_disk\_size | Root disk size in GB | `any` | n/a | yes |
 | boot\_disk\_type | The GCE boot disk type.Set to pd-standard (for PD HDD). | `string` | `"pd-ssd"` | no |
+| host\_project\_id | Shared VPC only - The ID of the host project containing the Shared VPC network. | `string` | `""` | no |
 | instance\_name | A unique name for the resource, required by GCE. Changing this forces a new resource to be created. | `any` | n/a | yes |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |
 | linux\_image\_family | GCE linux image family. | `any` | n/a | yes |

--- a/examples/sap_hana_simple_example/main.tf
+++ b/examples/sap_hana_simple_example/main.tf
@@ -27,6 +27,7 @@ module "gcp_sap_hana" {
   instance_name              = var.instance_name
   instance_type              = var.instance_type
   project_id                 = var.project_id
+  host_project_id            = var.host_project_id
   region                     = var.region
   zone                       = var.zone
   service_account_email      = var.service_account_email

--- a/examples/sap_hana_simple_example/variables.tf
+++ b/examples/sap_hana_simple_example/variables.tf
@@ -18,6 +18,11 @@ variable "project_id" {
   description = "The ID of the project in which the resources will be deployed."
 }
 
+variable "host_project_id" {
+  description = "Shared VPC only - The ID of the host project containing the Shared VPC network."
+  default     = ""
+}
+
 variable "zone" {
   description = "The zone that the instance should be created in."
 }

--- a/modules/netweaver/README.md
+++ b/modules/netweaver/README.md
@@ -123,6 +123,7 @@ The recommended way is to use a GCS Bucket in the following way.:
 | device\_2 | Device name | `string` | `"sapmnt"` | no |
 | device\_3 | Device name | `string` | `"swap"` | no |
 | disk\_type | The GCE data disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| host\_project\_id | Shared VPC only - The ID of the host project containing the Shared VPC network. | `string` | `""` | no |
 | instance\_name | A unique name for the resource, required by GCE. Changing this forces a new resource to be created. | `any` | n/a | yes |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |
 | linux\_image\_family | GCE image family. | `any` | n/a | yes |

--- a/modules/netweaver/main.tf
+++ b/modules/netweaver/main.tf
@@ -128,7 +128,7 @@ resource "google_compute_instance" "gcp_nw" {
 
   network_interface {
     subnetwork         = var.subnetwork
-    subnetwork_project = var.project_id
+    subnetwork_project = var.host_project_id != "" ? var.host_project_id : var.project_id
 
     dynamic "access_config" {
       for_each = var.public_ip == 1 ? ["external_ip"] : []

--- a/modules/netweaver/variables.tf
+++ b/modules/netweaver/variables.tf
@@ -18,6 +18,11 @@ variable "project_id" {
   description = "The ID of the project in which the resources will be deployed."
 }
 
+variable "host_project_id" {
+  description = "Shared VPC only - The ID of the host project containing the Shared VPC network."
+  default     = ""
+}
+
 variable "zone" {
   description = "The zone that the instance should be created in."
 }

--- a/modules/sap_hana/README.md
+++ b/modules/sap_hana/README.md
@@ -117,6 +117,7 @@ The recommended way is to use a GCS Bucket in the following way.:
 | disk\_name\_1 | Name of second disk. | `string` | `"sap-hana-pd-sd-1"` | no |
 | disk\_type\_0 | The GCE data disk type. May be set to pd-ssd. | `string` | `"pd-ssd"` | no |
 | disk\_type\_1 | The GCE data disk type. May be set to pd-standard (for PD HDD). | `string` | `"pd-standard"` | no |
+| host\_project\_id | Shared VPC only - The ID of the host project containing the Shared VPC network. | `string` | `""` | no |
 | instance\_name | A unique name for the resource, required by GCE. Changing this forces a new resource to be created. | `any` | n/a | yes |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |
 | linux\_image\_family | GCE image family. | `any` | n/a | yes |

--- a/modules/sap_hana/main.tf
+++ b/modules/sap_hana/main.tf
@@ -97,7 +97,7 @@ resource "google_compute_instance" "gcp_sap_hana" {
 
   network_interface {
     subnetwork         = var.subnetwork
-    subnetwork_project = var.project_id
+    subnetwork_project = var.host_project_id != "" ? var.host_project_id : var.project_id
 
     dynamic "access_config" {
       for_each = var.public_ip ? google_compute_address.gcp_sap_hana_ip : []

--- a/modules/sap_hana/variables.tf
+++ b/modules/sap_hana/variables.tf
@@ -18,6 +18,11 @@ variable "project_id" {
   description = "The ID of the project in which the resources will be deployed."
 }
 
+variable "host_project_id" {
+  description = "Shared VPC only - The ID of the host project containing the Shared VPC network."
+  default     = ""
+}
+
 variable "zone" {
   description = "The zone that the instance should be created in."
 }

--- a/modules/sap_hana_ha/README.md
+++ b/modules/sap_hana_ha/README.md
@@ -126,6 +126,7 @@ It is the recommended way is to use a GCS Bucket in the following way.:
 | disk\_name\_3 | Name of fourth disk. | `string` | `"sap-hana-pd-sd-3"` | no |
 | disk\_type\_0 | The GCE data disk type. May be set to pd-ssd. | `string` | `"pd-ssd"` | no |
 | disk\_type\_1 | The GCE data disk type. May be set to pd-standard (for PD HDD). | `string` | `"pd-standard"` | no |
+| host\_project\_id | Shared VPC only - The ID of the host project containing the Shared VPC network. | `string` | `""` | no |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |
 | linux\_image\_family | GCE image family. | `any` | n/a | yes |
 | linux\_image\_project | Project name containing the linux image. | `any` | n/a | yes |

--- a/modules/sap_hana_ha/variables.tf
+++ b/modules/sap_hana_ha/variables.tf
@@ -42,6 +42,11 @@ variable "project_id" {
   description = "The ID of the project in which the resources will be deployed."
 }
 
+variable "host_project_id" {
+  description = "Shared VPC only - The ID of the host project containing the Shared VPC network."
+  default     = ""
+}
+
 variable "region" {
   description = "Region to deploy the resources. Should be in the same region as the zone."
 }


### PR DESCRIPTION
Many SAP GCP deployments are performed in a shared VPC configuration. Currently, the scripts do not support deployment to a shared VPC.

in this PR, I propose to add a optional variable host_project_id that need to be set for deployment in Shared VPC or empty for a single VPC deployment.

Fix #22 