### PR TITLE
feat: Adding the option can_ip_forward to enable/disable IP forwarding

### DIFF
--- a/examples/netweaver_simple_example/README.md
+++ b/examples/netweaver_simple_example/README.md
@@ -33,6 +33,7 @@ Make sure you go through this [Requirements section](../../modules/netweaver/REA
 | autodelete\_disk | Whether the disk will be auto-deleted when the instance is deleted. | `string` | `"false"` | no |
 | boot\_disk\_size | Root disk size in GB. | `any` | n/a | yes |
 | boot\_disk\_type | The GCE boot disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| can\_ip\_forward | Allow IP forwarding for the instance | `bool` | `true` | no |
 | disk\_type | The GCE data disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
 | instance\_internal\_ip | Instance private ip address | `string` | `""` | no |
 | instance\_name | A unique name for the resource, required by GCE. Changing this forces a new resource to be created. | `any` | n/a | yes |

--- a/examples/netweaver_simple_example/main.tf
+++ b/examples/netweaver_simple_example/main.tf
@@ -42,6 +42,7 @@ module "gcp_netweaver" {
   disk_type              = var.disk_type
   startup_script         = var.startup_script
   instance_internal_ip   = var.instance_internal_ip
+  can_ip_forward         = var.can_ip_forward
   pd_kms_key             = google_kms_crypto_key.netweaver_simple.self_link
 }
 

--- a/examples/netweaver_simple_example/variables.tf
+++ b/examples/netweaver_simple_example/variables.tf
@@ -107,3 +107,8 @@ variable "instance_internal_ip" {
   description = "Instance private ip address"
   default     = ""
 }
+
+variable "can_ip_forward" {
+  description = "Allow IP forwarding for the instance"
+  default     = true
+}

--- a/examples/sap_hana_ha_simple_example/README.md
+++ b/examples/sap_hana_ha_simple_example/README.md
@@ -32,6 +32,7 @@ Make sure you go through this [Requirements section](../../modules/sap_hana_ha/R
 |------|-------------|------|---------|:--------:|
 | boot\_disk\_size | Root disk size in GB | `any` | n/a | yes |
 | boot\_disk\_type | The GCE data disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| can\_ip\_forward | Allow IP forwarding for the instance | `bool` | `true` | no |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |
 | linux\_image\_family | GCE image family. | `any` | n/a | yes |
 | linux\_image\_project | Project name containing the linux image. | `any` | n/a | yes |

--- a/examples/sap_hana_ha_simple_example/main.tf
+++ b/examples/sap_hana_ha_simple_example/main.tf
@@ -57,6 +57,7 @@ module "gcp_sap_hana_ha" {
   startup_script_2               = file(var.startup_script_2)
   primary_instance_internal_ip   = var.primary_instance_internal_ip
   secondary_instance_internal_ip = var.secondary_instance_internal_ip
+  can_ip_forward                 = var.can_ip_forward
   pd_kms_key                     = google_kms_crypto_key.sap_hana_ha_simple.self_link
 }
 

--- a/examples/sap_hana_ha_simple_example/variables.tf
+++ b/examples/sap_hana_ha_simple_example/variables.tf
@@ -159,3 +159,8 @@ variable "secondary_instance_internal_ip" {
   description = "Secondary instance private ip address"
   default     = ""
 }
+
+variable "can_ip_forward" {
+  description = "Allow IP forwarding for the instance"
+  default     = true
+}

--- a/examples/sap_hana_simple_example/README.md
+++ b/examples/sap_hana_simple_example/README.md
@@ -31,6 +31,7 @@ No provider.
 | autodelete\_disk | Whether the disk will be auto-deleted when the instance is deleted. | `bool` | `true` | no |
 | boot\_disk\_size | Root disk size in GB | `any` | n/a | yes |
 | boot\_disk\_type | The GCE boot disk type.Set to pd-standard (for PD HDD). | `string` | `"pd-ssd"` | no |
+| can\_ip\_forward | Allow IP forwarding for the instance | `bool` | `true` | no |
 | instance\_internal\_ip | Instance private ip address | `string` | `""` | no |
 | instance\_name | A unique name for the resource, required by GCE. Changing this forces a new resource to be created. | `any` | n/a | yes |
 | instance\_type | The GCE instance/machine type. | `any` | n/a | yes |

--- a/examples/sap_hana_simple_example/main.tf
+++ b/examples/sap_hana_simple_example/main.tf
@@ -48,5 +48,6 @@ module "gcp_sap_hana" {
   sap_hana_sapsys_gid        = 900
   public_ip                  = var.public_ip
   address_name               = var.address_name
+  can_ip_forward             = var.can_ip_forward
   instance_internal_ip       = var.instance_internal_ip
 }

--- a/examples/sap_hana_simple_example/variables.tf
+++ b/examples/sap_hana_simple_example/variables.tf
@@ -138,3 +138,8 @@ variable "instance_internal_ip" {
   description = "Instance private ip address"
   default     = ""
 }
+
+variable "can_ip_forward" {
+  description = "Allow IP forwarding for the instance"
+  default     = true
+}

--- a/modules/netweaver/README.md
+++ b/modules/netweaver/README.md
@@ -118,6 +118,7 @@ The recommended way is to use a GCS Bucket in the following way.:
 | autodelete\_disk | Whether the disk will be auto-deleted when the instance is deleted. | `string` | `"false"` | no |
 | boot\_disk\_size | Root disk size in GB. | `any` | n/a | yes |
 | boot\_disk\_type | The GCE boot disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| can\_ip\_forward | Allow IP forwarding for the instance | `bool` | `true` | no |
 | device\_0 | Device name | `string` | `"boot"` | no |
 | device\_1 | Device name | `string` | `"usrsap"` | no |
 | device\_2 | Device name | `string` | `"sapmnt"` | no |

--- a/modules/netweaver/main.tf
+++ b/modules/netweaver/main.tf
@@ -116,7 +116,7 @@ resource "google_compute_instance" "gcp_nw" {
   zone                      = var.zone
   tags                      = var.network_tags
   allow_stopping_for_update = true
-  can_ip_forward            = true
+  can_ip_forward            = var.can_ip_forward
 
   scheduling {
     automatic_restart   = true

--- a/modules/netweaver/variables.tf
+++ b/modules/netweaver/variables.tf
@@ -133,3 +133,8 @@ variable "instance_internal_ip" {
   description = "Instance private ip address"
   default     = ""
 }
+
+variable "can_ip_forward" {
+  description = "Allow IP forwarding for the instance"
+  default     = true
+}

--- a/modules/sap_hana/README.md
+++ b/modules/sap_hana/README.md
@@ -111,6 +111,7 @@ The recommended way is to use a GCS Bucket in the following way.:
 | autodelete\_disk | Whether the disk will be auto-deleted when the instance is deleted. | `string` | `"false"` | no |
 | boot\_disk\_size | Root disk size in GB. | `any` | n/a | yes |
 | boot\_disk\_type | The GCE boot disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| can\_ip\_forward | Allow IP forwarding for the instance | `bool` | `true` | no |
 | device\_name\_pd\_hdd | device name for standard persistant disk | `string` | `"backup"` | no |
 | device\_name\_pd\_ssd | device name for ssd persistant disk | `string` | `"pdssd"` | no |
 | disk\_name\_0 | Name of first disk. | `string` | `"sap-hana-pd-sd-0"` | no |

--- a/modules/sap_hana/main.tf
+++ b/modules/sap_hana/main.tf
@@ -79,7 +79,7 @@ resource "google_compute_instance" "gcp_sap_hana" {
   machine_type   = var.instance_type
   zone           = var.zone
   tags           = var.network_tags
-  can_ip_forward = true
+  can_ip_forward = var.can_ip_forward
 
   scheduling {
     automatic_restart   = true

--- a/modules/sap_hana/variables.tf
+++ b/modules/sap_hana/variables.tf
@@ -170,3 +170,8 @@ variable "instance_internal_ip" {
   description = "Instance private ip address"
   default     = ""
 }
+
+variable "can_ip_forward" {
+  description = "Allow IP forwarding for the instance"
+  default     = true
+}

--- a/modules/sap_hana_ha/README.md
+++ b/modules/sap_hana_ha/README.md
@@ -120,6 +120,7 @@ It is the recommended way is to use a GCS Bucket in the following way.:
 | autodelete\_disk | Whether the disk will be auto-deleted when the instance is deleted. | `string` | `"false"` | no |
 | boot\_disk\_size | Root disk size in GB | `any` | n/a | yes |
 | boot\_disk\_type | The GCE data disk type. May be set to pd-standard (for PD HDD) or pd-ssd. | `any` | n/a | yes |
+| can\_ip\_forward | Allow IP forwarding for the instance | `bool` | `true` | no |
 | disk\_name\_0 | Name of first disk. | `string` | `"sap-hana-pd-sd-0"` | no |
 | disk\_name\_1 | Name of second disk. | `string` | `"sap-hana-pd-sd-1"` | no |
 | disk\_name\_2 | Name of third disk. | `string` | `"sap-hana-pd-sd-2"` | no |

--- a/modules/sap_hana_ha/main.tf
+++ b/modules/sap_hana_ha/main.tf
@@ -138,7 +138,7 @@ resource "google_compute_instance" "primary" {
   machine_type   = var.instance_type
   zone           = var.primary_zone
   tags           = var.network_tags
-  can_ip_forward = true
+  can_ip_forward = var.can_ip_forward
 
   scheduling {
     automatic_restart   = true
@@ -214,7 +214,7 @@ resource "google_compute_instance" "secondary" {
   machine_type   = var.instance_type
   zone           = var.secondary_zone
   tags           = var.network_tags
-  can_ip_forward = true
+  can_ip_forward = var.can_ip_forward
 
   scheduling {
     automatic_restart   = true

--- a/modules/sap_hana_ha/variables.tf
+++ b/modules/sap_hana_ha/variables.tf
@@ -203,3 +203,8 @@ variable "secondary_instance_internal_ip" {
   description = "Secondary instance private ip address"
   default     = ""
 }
+
+variable "can_ip_forward" {
+  description = "Allow IP forwarding for the instance"
+  default     = true
+}


### PR DESCRIPTION
Currently, IP forwarding is enabled on instances created by the scripts.
This is mandatory when you want to use high availability and use the “route” method for the VIP movement. When using other methods like VIP alias ou VIP ILB, IP forwading, enabling IP forwarding is not necessary.
In addition, when running Security Command Center, the instance is flagged with a medium security level message regarding IP forwarding enabled and could be against customer security policies.

This PR adds the variable enable_ip_forward to enable or not IP forwarding for the instance. Its default value is true as the current implementaion.