### PR TITLE
fix: Update machine types in tests to use more modern types

### DIFF
--- a/examples/sap_hana_ha_simple/main.tf
+++ b/examples/sap_hana_ha_simple/main.tf
@@ -19,7 +19,7 @@ module "sap_hana_ha" {
   version = "~> 1.0"
 
   project_id              = var.project_id
-  machine_type            = "n1-standard-16"
+  machine_type            = "n2-standard-16"
   network                 = "default"
   subnetwork              = "default"
   linux_image             = "rhel-8-8-sap-ha"

--- a/examples/sap_hana_scaleout_simple/main.tf
+++ b/examples/sap_hana_scaleout_simple/main.tf
@@ -20,7 +20,7 @@ module "hana_scaleout" {
 
   project_id          = var.project_id
   zone                = "us-east1-b"
-  machine_type        = "n1-standard-16"
+  machine_type        = "n2-standard-16"
   subnetwork          = "default"
   linux_image         = "rhel-8-8-sap-ha"
   linux_image_project = "rhel-sap-cloud"

--- a/examples/sap_hana_simple/main.tf
+++ b/examples/sap_hana_simple/main.tf
@@ -19,7 +19,7 @@ module "sap_hana" {
   version = "~> 1.0"
 
   project_id          = var.project_id
-  machine_type        = "n1-standard-16"
+  machine_type        = "n2-standard-16"
   subnetwork          = "default"
   linux_image         = "rhel-8-8-sap-ha"
   linux_image_project = "rhel-sap-cloud"

--- a/examples/sap_nw_ha_simple/main.tf
+++ b/examples/sap_nw_ha_simple/main.tf
@@ -19,7 +19,7 @@ module "sap_nw_ha" {
   version = "~> 1.0"
 
   project_id              = var.project_id
-  machine_type            = "n1-standard-16"
+  machine_type            = "n2-standard-16"
   network                 = "default"
   subnetwork              = "default"
   linux_image             = "rhel-8-8-sap-ha"

--- a/examples/sap_nw_simple/main.tf
+++ b/examples/sap_nw_simple/main.tf
@@ -19,7 +19,7 @@ module "sap_nw" {
   version = "~> 1.0"
 
   project_id          = var.project_id
-  machine_type        = "n1-standard-16"
+  machine_type        = "n2-standard-16"
   subnetwork          = "default"
   linux_image         = "rhel-8-8-sap-ha"
   linux_image_project = "rhel-sap-cloud"

--- a/test/integration/sap_hana_ha_simple/sap_hana_ha_simple_test.go
+++ b/test/integration/sap_hana_ha_simple/sap_hana_ha_simple_test.go
@@ -38,7 +38,7 @@ func TestSapHanaHaSimpleModule(t *testing.T) {
 		for insType, insSelfLink := range instanceSelfLinks {
 			zone, name := common.GetInstanceNameAndZone(insSelfLink)
 			op := gcloud.Runf(t, "compute instances describe %s --zone %s --project %s", name, zone, sapHanaHa.GetTFSetupStringOutput("project_id"))
-			assert.Equal("n1-standard-16", common.GetInstanceMachineType(op.Get("machineType").String()), fmt.Sprintf("%s machine type set as n1-highmem-32", insType))
+			assert.Equal("n2-standard-16", common.GetInstanceMachineType(op.Get("machineType").String()), fmt.Sprintf("%s machine type set as n2-standard-16", insType))
 			insNetworkInterface := op.Get("networkInterfaces").Array()[0]
 			assert.Equal("default", common.GetInstanceNetworkName(insNetworkInterface.Get("network").String()), fmt.Sprintf("%s instance connected to default network", insType))
 			subnetRegion, subnetName := common.GetInstanceSubnetNameAndRegion(insNetworkInterface.Get("subnetwork").String())

--- a/test/integration/sap_hana_scaleout_simple/sap_hana_scaleout_simple_test.go
+++ b/test/integration/sap_hana_scaleout_simple/sap_hana_scaleout_simple_test.go
@@ -49,7 +49,7 @@ func TestSapHanaScaleoutModule(t *testing.T) {
 		for insType, insSelfLink := range instanceSelfLinks {
 			zone, name := common.GetInstanceNameAndZone(insSelfLink)
 			op := gcloud.Runf(t, "compute instances describe %s --zone %s --project %s", name, zone, sapHanaSc.GetTFSetupStringOutput("project_id"))
-			assert.Equal("n1-standard-16", common.GetInstanceMachineType(op.Get("machineType").String()), fmt.Sprintf("%s machine type set as n1-highmem-32", insType))
+			assert.Equal("n2-standard-16", common.GetInstanceMachineType(op.Get("machineType").String()), fmt.Sprintf("%s machine type set as n2-highmem-32", insType))
 			insNetworkInterface := op.Get("networkInterfaces").Array()[0]
 			assert.Equal("default", common.GetInstanceNetworkName(insNetworkInterface.Get("network").String()), fmt.Sprintf("%s instance connected to default network", insType))
 			subnetRegion, subnetName := common.GetInstanceSubnetNameAndRegion(insNetworkInterface.Get("subnetwork").String())

--- a/test/integration/sap_hana_simple/sap_hana_simple_test.go
+++ b/test/integration/sap_hana_simple/sap_hana_simple_test.go
@@ -37,7 +37,7 @@ func TestSapHanaSimpleModule(t *testing.T) {
 		for insType, insSelfLink := range instanceSelfLinks {
 			zone, name := common.GetInstanceNameAndZone(insSelfLink)
 			op := gcloud.Runf(t, "compute instances describe %s --zone %s --project %s", name, zone, sapHana.GetTFSetupStringOutput("project_id"))
-			assert.Equal("n1-standard-16", common.GetInstanceMachineType(op.Get("machineType").String()), fmt.Sprintf("%s machine type set as n1-highmem-32", insType))
+			assert.Equal("n2-standard-16", common.GetInstanceMachineType(op.Get("machineType").String()), fmt.Sprintf("%s machine type set as n2-highmem-32", insType))
 			insNetworkInterface := op.Get("networkInterfaces").Array()[0]
 			assert.Equal("default", common.GetInstanceNetworkName(insNetworkInterface.Get("network").String()), fmt.Sprintf("%s instance connected to default network", insType))
 			subnetRegion, subnetName := common.GetInstanceSubnetNameAndRegion(insNetworkInterface.Get("subnetwork").String())


### PR DESCRIPTION
Migrates examples and tests to use n2 machine types, as n1 machine types are no longer widely available.